### PR TITLE
add memcache extension for php 7.1

### DIFF
--- a/Formula/php@7.1-memcache.rb
+++ b/Formula/php@7.1-memcache.rb
@@ -1,0 +1,15 @@
+require File.expand_path("../lib/php_extension_formula", __dir__)
+
+class PhpAT71Memcache < PhpExtensionFormula
+  extension_dsl "Memcache Extension"
+
+  url "https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz"
+  sha256 "8a14cb069cd8ec06db24db630c7c8405a7417b1a3d821bac34f2177ed5208439"
+
+  def install
+    system php_parent.bin/"phpize"
+    system "./configure", *configure_args
+    system "make"
+    (lib/module_path).install "modules/#{extension}.so"
+  end
+end


### PR DESCRIPTION
created brew based on the gist: https://gist.github.com/Niteshvgupta/1832ce29dee460b64d5384e4f585e7ab

the `def install` override is made to omit `cd ext/#{extension}`.

probably could be done better.

but works here:
```
[/tmp] ➔ brew install php@7.1-memcache
==> Installing php@7.1-memcache from kabel/php-ext
==> Downloading https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz
Already downloaded: /Users/glen/Library/Caches/Homebrew/downloads/5e148a25d7731c41b7881efd93b4c535207402e2e4fd789efaceea174c7e5be6--pecl-memcache-NON_BLOCKING_IO_php7.tar.gz
==> /usr/local/opt/php@7.1/bin/phpize
==> ./configure --with-php-config=/usr/local/opt/php@7.1/bin/php-config
==> make
🍺  /usr/local/Cellar/php@7.1-memcache/7: 5 files, 103.8KB, built in 17 seconds
[/tmp] ➔
```