### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/Formula/php-imap.rb
+++ b/Formula/php-imap.rb
@@ -5,12 +5,15 @@ class PhpImap < PhpExtensionFormula
 
   conflicts_with "php-recode", :because => "because both share the same internal symbols"
 
+  depends_on "krb5"
   depends_on "imap-uw"
   depends_on "openssl@1.1"
+
+  ENV['PHP_OPENSSL'] = 'yes'
 
   configure_arg %W[
     --with-imap=#{Formula["imap-uw"].opt_prefix}
     --with-imap-ssl=#{Formula["openssl@1.1"].opt_prefix}
-    --with-kerberos
+    --with-kerberos=#{Formula["krb5"].opt_prefix}
   ]
 end


### PR DESCRIPTION
This PR
- adds `krb5` as a dependency
- sets `PHP_OPENSSL=yes` (workaround found in [Docker](https://github.com/docker-library/php/issues/891#issuecomment-531023107))